### PR TITLE
fix(README): '+' instead of '-' in key combinaitons

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ You can set your own key-bindings for examples as
 ```python
 config.bind(';t', 'hint userscript link translate')
 config.bind(';T', 'hint userscript all translate --text')
-config.bind('<Ctrl-T>', 'spawn --userscript translate')
-config.bind('<Ctrl-Shift-T>', 'spawn --userscript translate --text')
+config.bind('<Ctrl+T>', 'spawn --userscript translate')
+config.bind('<Ctrl+Shift+T>', 'spawn --userscript translate --text')
 ```
 
 ## Contributions


### PR DESCRIPTION
Copied commit from https://github.com/AckslD/Qute-Translate/pull/1 into a separate PR